### PR TITLE
Versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+downloads/
+.DS_store

--- a/findsimulator.rb
+++ b/findsimulator.rb
@@ -1,7 +1,7 @@
 class Findsimulator < Formula
   desc "Compute 'destination' for xcodebuild command line tool to build Xcode projects."
   homepage "https://github.com/a7ex/findsimulator"
-  version "0.3"
+  version "0.3.0"
   url "https://github.com/a7ex/findsimulator/archive/0.3.tar.gz"
   sha256 "9389387a20173180d1e91cc8e1edeebea48438aeff6df04ab0714b9b86a414be"
   license "MIT"

--- a/findsimulator@0.3.rb
+++ b/findsimulator@0.3.rb
@@ -1,7 +1,7 @@
 class FindsimulatorAT03 < Formula
   desc "Compute 'destination' for xcodebuild command line tool to build Xcode projects."
   homepage "https://github.com/a7ex/findsimulator"
-  version "0.3"
+  version "0.3.0"
   url "https://github.com/a7ex/findsimulator/archive/0.3.tar.gz"
   sha256 "9389387a20173180d1e91cc8e1edeebea48438aeff6df04ab0714b9b86a414be"
   license "MIT"

--- a/findsimulator@0.3.rb
+++ b/findsimulator@0.3.rb
@@ -1,4 +1,4 @@
-class Findsimulator < Formula
+class FindsimulatorAT03 < Formula
   desc "Compute 'destination' for xcodebuild command line tool to build Xcode projects."
   homepage "https://github.com/a7ex/findsimulator"
   version "0.3"

--- a/generator/gen.py
+++ b/generator/gen.py
@@ -1,0 +1,141 @@
+import hashlib
+import json
+import os
+import urllib.request
+from pathlib import Path
+
+def sha256sum(filename):
+    with open(filename, 'rb', buffering=0) as f:
+        return hashlib.file_digest(f, 'sha256').hexdigest()
+
+
+def generate_text(user, repo, description, version, sha256, assert_string, command, is_latest_version):
+    class_name = f'{repo.capitalize()}AT{version.replace(".", "")}'
+
+    if (is_latest_version):
+        class_name = repo.capitalize()
+
+    return f'''class {class_name} < Formula
+  desc "{description}"
+  homepage "https://github.com/{user}/{repo}"
+  version "{version}"
+  url "https://github.com/{user}/{repo}/archive/{version}.tar.gz"
+  sha256 "{sha256}"
+  license "MIT"
+
+  depends_on xcode: ["10.0", :build]
+
+  def install
+    system "make", "install", "prefix=#{{prefix}}"
+  end
+
+  test do
+    assert_match "{assert_string}", shell_output("{command}")
+  end
+
+end
+'''
+
+def generate_version_list(url):
+  print(url)
+  response = urllib.request.urlopen(url).read()
+  response_object = json.loads(response)
+
+  versions_list = []
+
+  for release in response_object:
+      if (release['prerelease']):
+          continue
+      
+      versions_list.append((release['tag_name'], release))
+
+  versions_list = list(map(lambda s: ([int(u) for u in s[0].split('.')], s[1]), versions_list))
+  versions_list.sort(reverse=True, key=lambda s: s[0])
+
+  latest_minor_versions = [versions_list[0]]
+  latest_major = versions_list[0][0][0]
+  latest_minor = versions_list[0][0][1]
+
+  for version in versions_list[1:]:
+      major = version[0][0]
+      minor = 0
+
+      if (len(version[0]) > 1):
+          minor = version[0][1]
+
+      if ((major == latest_major) and (minor == latest_minor)):
+          continue
+
+      latest_minor_versions.append(version)
+      latest_major = major
+      latest_minor = minor
+
+  return latest_minor_versions
+
+def generate_formulae(user, repo, description, assert_string, command):
+  base_dir = os.path.abspath(os.path.dirname(__file__))
+  download_dir = os.path.join(base_dir, 'downloads')
+  Path(download_dir).mkdir(parents=True, exist_ok=True)
+
+  url = f'https://api.github.com/repos/{user}/{repo}/releases'
+  is_latest_version = True
+
+  for (version_list, release) in generate_version_list(url):
+      if (release['prerelease']):
+          continue
+      
+      print(f'Tag: {release['tag_name']}')
+      version = release['tag_name']
+      
+      version_file_path = os.path.join(base_dir, f'../{repo.lower()}@{version}.rb')
+
+      if os.path.isfile(version_file_path):
+          continue
+
+      # Undeniably a bit of a hack to generate version strings for findsimulator
+      # but not sure how else to best match behavior here.
+      if assert_string is None:
+          numbers = version.split('.')
+          if len(numbers) == 3:
+              numbers = numbers[:-1]
+          assert_string = '.'.join(numbers)
+
+      filename = os.path.join(download_dir, f'{version}.tar.gz')
+      file_url = f'https://github.com/{user}/{repo}/archive/{release['tag_name']}.tar.gz'
+      print(f'\tfile_url: {file_url}')
+      urllib.request.urlretrieve(file_url, filename)
+      sha256 = sha256sum(filename)
+      print(f'\tSHA256: {sha256}')
+
+      with open(version_file_path, "w") as text_file:
+          text_file.write(generate_text(user, repo, description, version, sha256, assert_string, command, False))
+
+      if (is_latest_version):
+          is_latest_version = False
+
+          with open(os.path.join(base_dir, f'../{repo.lower()}.rb'), "w") as text_file:
+              text_file.write(generate_text(user, repo, description, version, sha256, assert_string, command, True))
+
+generate_formulae(
+    'a7ex', 
+    'findsimulator', 
+    "Compute 'destination' for xcodebuild command line tool to build Xcode projects.",
+    None,
+    '#{bin}/findsimulator -v'
+    )
+
+generate_formulae(
+    'a7ex', 
+    'SBEnumerator', 
+    'Parse Xcode Interface Builder files and create enums for cell identifiers and accessibility identifiers',
+    "Error: Argument error. No Interface Builder file was provided. Use --help for a usage description.",
+    '#{bin}/sbenumerator'
+    )
+
+generate_formulae(
+    'a7ex', 
+    'xcresultparser', 
+    'Parse .xcresult files and print summary in different formats',
+    "Missing expected argument '<xcresult-file>'",
+    '#{bin}/xcresultparser -o txt'
+    )

--- a/generator/gen.py
+++ b/generator/gen.py
@@ -15,10 +15,16 @@ def generate_text(user, repo, description, version, sha256, testing_section, is_
     if (is_latest_version):
         class_name = repo.capitalize()
 
+    semver = version
+
+    version_len = len(version.split('.'))
+    if (version_len != 3):
+        semver = semver + ('.0' * (3 - version_len))
+
     return f'''class {class_name} < Formula
   desc "{description}"
   homepage "https://github.com/{user}/{repo}"
-  version "{version}"
+  version "{semver}"
   url "https://github.com/{user}/{repo}/archive/{version}.tar.gz"
   sha256 "{sha256}"
   license "MIT"

--- a/sbenumerator@1.0.3.rb
+++ b/sbenumerator@1.0.3.rb
@@ -1,0 +1,19 @@
+class SbenumeratorAT103 < Formula
+  desc "Parse Xcode Interface Builder files and create enums for cell identifiers and accessibility identifiers"
+  homepage "https://github.com/a7ex/SBEnumerator"
+  version "1.0.3"
+  url "https://github.com/a7ex/SBEnumerator/archive/1.0.3.tar.gz"
+  sha256 "6fb75774fb96423560e062eed832ac47326a79fab3d03cd50b5c9f8ec8734c9a"
+  license "MIT"
+
+  depends_on xcode: ["10.0", :build]
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    assert_match "Error: Argument error. No Interface Builder file was provided. Use --help for a usage description.", shell_output("#{bin}/sbenumerator")
+  end
+
+end

--- a/xcresultparser@1.0.5.rb
+++ b/xcresultparser@1.0.5.rb
@@ -1,0 +1,19 @@
+class XcresultparserAT105 < Formula
+  desc "Parse .xcresult files and print summary in different formats"
+  homepage "https://github.com/a7ex/xcresultparser"
+  version "1.0.5"
+  url "https://github.com/a7ex/xcresultparser/archive/1.0.5.tar.gz"
+  sha256 "fd561e7f4c3c1dbaa034a34ce32f4788801426f29d63072c59e95786170812b8"
+  license "MIT"
+
+  depends_on xcode: ["10.0", :build]
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    assert_match "Missing expected argument '<xcresult-file>'", shell_output("#{bin}/xcresultparser -o txt")
+  end
+
+end

--- a/xcresultparser@1.1.6.rb
+++ b/xcresultparser@1.1.6.rb
@@ -1,0 +1,19 @@
+class XcresultparserAT116 < Formula
+  desc "Parse .xcresult files and print summary in different formats"
+  homepage "https://github.com/a7ex/xcresultparser"
+  version "1.1.6"
+  url "https://github.com/a7ex/xcresultparser/archive/1.1.6.tar.gz"
+  sha256 "7d5224fada9144449557cadbbd45699d7543262787cdc91b9a8c7d62dd9c6023"
+  license "MIT"
+
+  depends_on xcode: ["10.0", :build]
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    assert_match "Missing expected argument '<xcresult-file>'", shell_output("#{bin}/xcresultparser -o txt")
+  end
+
+end

--- a/xcresultparser@1.2.2.rb
+++ b/xcresultparser@1.2.2.rb
@@ -1,0 +1,19 @@
+class XcresultparserAT122 < Formula
+  desc "Parse .xcresult files and print summary in different formats"
+  homepage "https://github.com/a7ex/xcresultparser"
+  version "1.2.2"
+  url "https://github.com/a7ex/xcresultparser/archive/1.2.2.tar.gz"
+  sha256 "7854c5e1d2ce5ec116aab11762422527b7e981aef4bf15321594a0f80d737bb0"
+  license "MIT"
+
+  depends_on xcode: ["10.0", :build]
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    assert_match "Missing expected argument '<xcresult-file>'", shell_output("#{bin}/xcresultparser -o txt")
+  end
+
+end

--- a/xcresultparser@1.3.1.rb
+++ b/xcresultparser@1.3.1.rb
@@ -1,0 +1,19 @@
+class XcresultparserAT131 < Formula
+  desc "Parse .xcresult files and print summary in different formats"
+  homepage "https://github.com/a7ex/xcresultparser"
+  version "1.3.1"
+  url "https://github.com/a7ex/xcresultparser/archive/1.3.1.tar.gz"
+  sha256 "8a4ea2f17d7cbcef24591007bb89f886de29527989047a0e049649aee331d17d"
+  license "MIT"
+
+  depends_on xcode: ["10.0", :build]
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    assert_match "Missing expected argument '<xcresult-file>'", shell_output("#{bin}/xcresultparser -o txt")
+  end
+
+end

--- a/xcresultparser@1.4.2.rb
+++ b/xcresultparser@1.4.2.rb
@@ -1,0 +1,19 @@
+class XcresultparserAT142 < Formula
+  desc "Parse .xcresult files and print summary in different formats"
+  homepage "https://github.com/a7ex/xcresultparser"
+  version "1.4.2"
+  url "https://github.com/a7ex/xcresultparser/archive/1.4.2.tar.gz"
+  sha256 "e0a1d07e62cabc319fb8ac6f9fc744ac46ecc7529b8f398a68688eb2746e0a46"
+  license "MIT"
+
+  depends_on xcode: ["10.0", :build]
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    assert_match "Missing expected argument '<xcresult-file>'", shell_output("#{bin}/xcresultparser -o txt")
+  end
+
+end

--- a/xcresultparser@1.5.2.rb
+++ b/xcresultparser@1.5.2.rb
@@ -1,0 +1,19 @@
+class XcresultparserAT152 < Formula
+  desc "Parse .xcresult files and print summary in different formats"
+  homepage "https://github.com/a7ex/xcresultparser"
+  version "1.5.2"
+  url "https://github.com/a7ex/xcresultparser/archive/1.5.2.tar.gz"
+  sha256 "6b770f96d67295105cb6d13039be66de54513d773c47cfc766a380ca41f7882a"
+  license "MIT"
+
+  depends_on xcode: ["10.0", :build]
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    assert_match "Missing expected argument '<xcresult-file>'", shell_output("#{bin}/xcresultparser -o txt")
+  end
+
+end

--- a/xcresultparser@1.6.5.rb
+++ b/xcresultparser@1.6.5.rb
@@ -1,0 +1,19 @@
+class XcresultparserAT165 < Formula
+  desc "Parse .xcresult files and print summary in different formats"
+  homepage "https://github.com/a7ex/xcresultparser"
+  version "1.6.5"
+  url "https://github.com/a7ex/xcresultparser/archive/1.6.5.tar.gz"
+  sha256 "7e354bd2d0d2958df748727ebac6e2357a3afb2689b33780cba429f0bfa8771a"
+  license "MIT"
+
+  depends_on xcode: ["10.0", :build]
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    assert_match "Missing expected argument '<xcresult-file>'", shell_output("#{bin}/xcresultparser -o txt")
+  end
+
+end

--- a/xcresultparser@1.7.2.rb
+++ b/xcresultparser@1.7.2.rb
@@ -1,0 +1,19 @@
+class XcresultparserAT172 < Formula
+  desc "Parse .xcresult files and print summary in different formats"
+  homepage "https://github.com/a7ex/xcresultparser"
+  version "1.7.2"
+  url "https://github.com/a7ex/xcresultparser/archive/1.7.2.tar.gz"
+  sha256 "6e8683cf6c39ead511d529c23914efca58a1c15c51dec9f6528b16e53af98fc5"
+  license "MIT"
+
+  depends_on xcode: ["10.0", :build]
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    assert_match "Missing expected argument '<xcresult-file>'", shell_output("#{bin}/xcresultparser -o txt")
+  end
+
+end


### PR DESCRIPTION
This should hit everything we discussed in #2 I think, but there may be things I'm unaware of.

This should generate any new versions for new releases you've published, and will update the default formula when there's a new latest. It won't redownload/regenerate any releases you already have. So you shouldn't need to mess around with manually adjusting these beyond just running the script and pushing (unless you want to change the generated files, in which case you can change the generator, delete the files, then run the generator to remake them all.

The only caveat I can think of might be if you release a new patch release for an older minor release:  it won't proactively delete the old patch version, that would need to be manual.

Feel free to know if I'm missing anything :)