### PR TITLE
Fix versioned formula class names to use Homebrew AT convention

### DIFF
--- a/xcresultparser@1.8.5.rb
+++ b/xcresultparser@1.8.5.rb
@@ -1,4 +1,4 @@
-class Xcresultparser < Formula
+class XcresultparserAT185 < Formula
   desc "Parse .xcresult files and print summary in different formats"
   homepage "https://github.com/a7ex/xcresultparser"
   version "1.8.5"

--- a/xcresultparser@1.9.0.rb
+++ b/xcresultparser@1.9.0.rb
@@ -1,4 +1,4 @@
-class Xcresultparser < Formula
+class XcresultparserAT190 < Formula
   desc "Parse .xcresult files and print summary in different formats"
   homepage "https://github.com/a7ex/xcresultparser"
   version "1.9.0"

--- a/xcresultparser@1.9.1.rb
+++ b/xcresultparser@1.9.1.rb
@@ -1,4 +1,4 @@
-class Xcresultparser < Formula
+class XcresultparserAT191 < Formula
   desc "Parse .xcresult files and print summary in different formats"
   homepage "https://github.com/a7ex/xcresultparser"
   version "1.9.1"

--- a/xcresultparser@1.9.2.rb
+++ b/xcresultparser@1.9.2.rb
@@ -1,4 +1,4 @@
-class Xcresultparser < Formula
+class XcresultparserAT192 < Formula
   desc "Parse .xcresult files and print summary in different formats"
   homepage "https://github.com/a7ex/xcresultparser"
   version "1.9.2"

--- a/xcresultparser@1.9.3.rb
+++ b/xcresultparser@1.9.3.rb
@@ -1,4 +1,4 @@
-class Xcresultparser < Formula
+class XcresultparserAT193 < Formula
   desc "Parse .xcresult files and print summary in different formats"
   homepage "https://github.com/a7ex/xcresultparser"
   version "1.9.3"

--- a/xcresultparser@1.9.4.rb
+++ b/xcresultparser@1.9.4.rb
@@ -1,4 +1,4 @@
-class Xcresultparser < Formula
+class XcresultparserAT194 < Formula
   desc "Parse .xcresult files and print summary in different formats"
   homepage "https://github.com/a7ex/xcresultparser"
   version "1.9.4"

--- a/xcresultparser@2.0.0-beta.rb
+++ b/xcresultparser@2.0.0-beta.rb
@@ -1,4 +1,4 @@
-class Xcresultparser < Formula
+class XcresultparserAT200Beta < Formula
   desc "Parse .xcresult files and print summary in different formats"
   homepage "https://github.com/a7ex/xcresultparser"
   version "2.0.0-beta"

--- a/xcresultparser@2.0.0.rb
+++ b/xcresultparser@2.0.0.rb
@@ -1,4 +1,4 @@
-class Xcresultparser < Formula
+class XcresultparserAT200 < Formula
   desc "Parse .xcresult files and print summary in different formats"
   homepage "https://github.com/a7ex/xcresultparser"
   version "2.0.0"


### PR DESCRIPTION
## Summary
We can currently pin this CLI to a specific version by downloading the zip file via Github releases as a workaround but would prefer to download pinned versions via `brew`, this fixes it. Looks like `generator/gen.py` was no longer being used as of `1.8.5` onwards.

- Versioned formula files from `@1.8.5` onward use `class Xcresultparser` instead of the Homebrew-conventional `XcresultparserATxxx` class names
- This causes `brew install xcresultparser@<version>` to fail with: `Expected to find class XcresultparserATxxx, but only found: Xcresultparser`
- This PR renames the class in all 8 affected formula files to their correct AT-convention names

## Details

The following files were fixed:

| File | Old Class | New Class |
|------|-----------|-----------|
| `xcresultparser@1.8.5.rb` | `Xcresultparser` | `XcresultparserAT185` |
| `xcresultparser@1.9.0.rb` | `Xcresultparser` | `XcresultparserAT190` |
| `xcresultparser@1.9.1.rb` | `Xcresultparser` | `XcresultparserAT191` |
| `xcresultparser@1.9.2.rb` | `Xcresultparser` | `XcresultparserAT192` |
| `xcresultparser@1.9.3.rb` | `Xcresultparser` | `XcresultparserAT193` |
| `xcresultparser@1.9.4.rb` | `Xcresultparser` | `XcresultparserAT194` |
| `xcresultparser@2.0.0-beta.rb` | `Xcresultparser` | `XcresultparserAT200Beta` |
| `xcresultparser@2.0.0.rb` | `Xcresultparser` | `XcresultparserAT200` |

Note: The `gen.py` generator script already produces correct class names - these 8 formulas appear to have been created manually without using it.